### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest] # , macos-latest, windows-latest
+        runner: [ubuntu-latest, macos-latest, windows-latest]
         perl: [ '5.32' ]
 
     runs-on: ${{matrix.runner}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Perl
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest] # , macos-latest, windows-latest
+        perl: [ '5.32' ]
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( startsWith( matrix.runner, 'windows-' ) && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Dist::Zilla
+      run: |
+        cpanm -v
+        cpanm --notest Dist::Zilla
+
+    - name: Install Modules
+      run: |
+        dzil authordeps --missing | cpanm --notest
+        #dzil listdeps --missing | cpanm --notest
+
+    - name: Run tests
+      run: |
+        dzil test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install Modules
       run: |
         dzil authordeps --missing | cpanm --notest
-        #dzil listdeps --missing | cpanm --notest
+        dzil listdeps --missing | cpanm --notest
 
     - name: Run tests
       run: |


### PR DESCRIPTION
I was surprised to see that installing the dependencies listed by `dzil authordeps --missing` was not enough and I had to also install the ones listed by `dzil listdeps --missing`. Is that the correct way?

If you are interested I have a few blog posts and videos regarding GitHub Actions: https://perlmaven.com/os